### PR TITLE
feat: User 도메인 추가 및 User 조회 API 구현

### DIFF
--- a/src/main/java/com/kidk/api/config/SecurityConfig.java
+++ b/src/main/java/com/kidk/api/config/SecurityConfig.java
@@ -1,4 +1,30 @@
 package com.kidk.api.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
 public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http
+                // 개발 단계라 CSRF 끔
+                .csrf(csrf -> csrf.disable())
+                // 요청 권한 설정
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/**").permitAll()
+                        .anyRequest().permitAll()
+                )
+                // 기본 로그인 폼/HTTP Basic 도 일단 끔
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable());
+
+        return http.build();
+    }
 }

--- a/src/main/java/com/kidk/api/domain/user/User.java
+++ b/src/main/java/com/kidk/api/domain/user/User.java
@@ -1,4 +1,75 @@
 package com.kidk.api.domain.user;
 
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "users",
+        indexes = {
+                @Index(name = "idx_users_firebase_uid", columnList = "firebase_uid"),
+                @Index(name = "idx_users_email", columnList = "email"),
+                @Index(name = "idx_users_social_provider_id", columnList = "social_provider_id"),
+                @Index(name = "idx_users_status", columnList = "status"),
+                @Index(name = "idx_users_last_login_at", columnList = "last_login_at")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "firebase_uid", nullable = false, unique = true, length = 255)
+    private String firebaseUid;
+
+    @Column(nullable = false, unique = true, length = 255)
+    private String email;
+
+    @Column(name = "social_provider", length = 50)
+    private String socialProvider;       // APPLE, KAKAO, NAVER, EMAIL
+
+    @Column(name = "social_provider_id", length = 255)
+    private String socialProviderId;     // 소셜 로그인 제공자의 고유 ID
+
+    @Column(name = "user_type", nullable = false, length = 20)
+    private String userType;             // CHILD, PARENT
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Lob
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;      // Firebase Storage URL
+
+    @Column(name = "birth_date")
+    private LocalDate birthDate;         // 어린이 연령 확인용
+
+    @Column(length = 20)
+    private String phone;                // 부모 연락처 (선택)
+
+    @Column(nullable = false, length = 20)
+    private String status = "ACTIVE";    // ACTIVE, DORMANT, WITHDRAWN, DELETED
+
+    @Column(name = "status_changed_at")
+    private LocalDateTime statusChangedAt;
+
+    @Column(name = "created_at", nullable = false,
+            columnDefinition = "timestamp default current_timestamp")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false,
+            columnDefinition = "timestamp default current_timestamp on update current_timestamp")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
 }

--- a/src/main/java/com/kidk/api/domain/user/UserController.java
+++ b/src/main/java/com/kidk/api/domain/user/UserController.java
@@ -1,4 +1,22 @@
 package com.kidk.api.domain.user;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
 public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping
+    public List<User> getUsers() {
+
+        return userService.getAllUsers();
+    }
 }

--- a/src/main/java/com/kidk/api/domain/user/UserRepository.java
+++ b/src/main/java/com/kidk/api/domain/user/UserRepository.java
@@ -1,0 +1,7 @@
+package com.kidk.api.domain.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/com/kidk/api/domain/user/UserRespository.java
+++ b/src/main/java/com/kidk/api/domain/user/UserRespository.java
@@ -1,4 +1,0 @@
-package com.kidk.api.domain.user;
-
-public class UserRespository {
-}

--- a/src/main/java/com/kidk/api/domain/user/UserService.java
+++ b/src/main/java/com/kidk/api/domain/user/UserService.java
@@ -1,4 +1,17 @@
 package com.kidk.api.domain.user;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class UserService {
+
+    private final UserRepository userRepository;
+
+    public List<User> getAllUsers() {
+        return userRepository.findAll();
+    }
 }


### PR DESCRIPTION
## ✨ Summary

- `users` 테이블에 매핑되는 User 도메인과
- DB 값을 조회해 내려주는 `/api/users` 공개 API를 추가했습니다.
- 개발 단계에서 편하게 호출할 수 있도록 Spring Security 기본 인증을 비활성화했습니다.

---

## 🔧 Changes

### 1. User 도메인 추가
- `com.kidk.api.domain.user.User`
  - ERD 기반으로 `users` 테이블 매핑
  - 주요 컬럼:
    - `firebaseUid`, `email`, `socialProvider`, `socialProviderId`
    - `userType`(CHILD/PARENT), `name`, `phone`, `status` 등
  - 인덱스 설정:
    - `firebase_uid`, `email`, `social_provider_id`, `status`, `last_login_at`

### 2. User Repository / Service / Controller
- `UserRepository`
  - `JpaRepository<User, Long>` 상속
  - 기본 CRUD 사용 (추가 메서드 없음)
- `UserService`
  - `getAllUsers()` : `userRepository.findAll()` 단순 위임
- `UserController`
  - `@RestController`, `@RequestMapping("/api/users")`
  - `GET /api/users` : 전체 사용자 리스트 조회

### 3. SecurityConfig 기본 설정
- `com.kidk.api.security.SecurityConfig`
  - Spring Security 기본 설정 커스터마이징
  - `csrf` 비활성화
  - `requestMatchers("/api/**").permitAll()` 로 API 전체 공개
  - `formLogin`, `httpBasic` 비활성화
  - 현재는 개발용 설정이며, 이후 JWT 기반 인증으로 대체 예정

---

## 🧪 How to Test

1. MySQL에 `kidk` DB 및 `users` 테이블 존재 확인
2. 테스트 데이터 추가 (예시)
   ```sql
   INSERT INTO users (
     firebase_uid, email, social_provider, social_provider_id,
     user_type, name, birth_date, phone, status
   ) VALUES (
     'test-uid-123',
     'child@example.com',
     'KAKAO',
     'kakao-123',
     'CHILD',
     '테스트 어린이',
     '2015-01-01',
     '010-0000-0000',
     'ACTIVE'
   );
   ```
3. 애플리케이션 실행 후 Postman에서 다음 호출 
- GET http://localhost:8080/api/users
4. 응답으로 사용자 리스트(JSON 배열)가 내려오는 지 확인 

---

## 📌 Notes / Next Steps
- 현재는 엔티티를 그대로 반환하고 있음 → 이후 DTO 레이어 추가 예정 
- SecurityConfig는 개발용 전면 허용 상태 → 추후 JWT 기반 인증/인가 설계 후 권한 제한 필요 
- 다음 작업 예정 
  - friend 도메인 추가 (엔티티, 레포지토리, 서비스, 컨트롤러)
  - /api/friends 조회 API 1차 구현 