### PR TITLE
feat: Family 도메인 추가 및 가족 조회 API 구현

### DIFF
--- a/src/main/java/com/kidk/api/domain/family/Family.java
+++ b/src/main/java/com/kidk/api/domain/family/Family.java
@@ -1,4 +1,22 @@
 package com.kidk.api.domain.family;
 
-public class Family {
+import com.kidk.api.domain.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name="families")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Family extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "family_name", length = 100)
+    private String familyName;
 }

--- a/src/main/java/com/kidk/api/domain/family/FamilyController.java
+++ b/src/main/java/com/kidk/api/domain/family/FamilyController.java
@@ -1,4 +1,28 @@
 package com.kidk.api.domain.family;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/families")
+@RequiredArgsConstructor
 public class FamilyController {
+
+    private final FamilyService familyService;
+
+    // 전체 조회 (테스트용)
+    @GetMapping
+    public List<Family> getFamilies() {
+        return familyService.findAll();
+    }
+
+    @GetMapping("/{familyId}")
+    public Family getFamily(@PathVariable Long familyId) {
+        return familyService.findById(familyId);
+    }
 }

--- a/src/main/java/com/kidk/api/domain/family/FamilyRepository.java
+++ b/src/main/java/com/kidk/api/domain/family/FamilyRepository.java
@@ -1,4 +1,6 @@
 package com.kidk.api.domain.family;
 
-public class FamilyRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FamilyRepository extends JpaRepository<Family, Long> {
 }

--- a/src/main/java/com/kidk/api/domain/family/FamilyService.java
+++ b/src/main/java/com/kidk/api/domain/family/FamilyService.java
@@ -1,4 +1,24 @@
 package com.kidk.api.domain.family;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class FamilyService {
+
+    private final FamilyRepository familyRepository;
+
+    // 가족 전체 목록 조회 (테스트용)
+    public List<Family> findAll() {
+        return familyRepository.findAll();
+    }
+
+    // 특정 가족 단일 조회
+    public Family findById(Long id) {
+        return familyRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Family Not Found")) ;
+    }
 }

--- a/src/test/java/com/kidk/api/domain/family/FamilyRepositoryTest.java
+++ b/src/test/java/com/kidk/api/domain/family/FamilyRepositoryTest.java
@@ -1,0 +1,30 @@
+package com.kidk.api.domain.family;
+
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@Transactional
+public class FamilyRepositoryTest {
+
+
+    @Autowired
+    private FamilyRepository familyRepository;
+
+    @Test
+    void save_and_find() {
+        Family family = Family.builder()
+                .familyName("test")
+                .build();
+
+        Family saved = familyRepository.save(family);
+        Family found = familyRepository.findById(saved.getId()).orElseThrow();
+
+        assertEquals(saved.getId(), found.getId());
+    }
+
+}

--- a/src/test/java/com/kidk/api/domain/friend/FriendRepositoryTest.java
+++ b/src/test/java/com/kidk/api/domain/friend/FriendRepositoryTest.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-public class FriendRepositoryTest {
+class FriendRepositoryTest {
 
     @Autowired
     private FriendRepository friendRepository;


### PR DESCRIPTION

## ✨ Summary

* `families` 테이블에 매핑되는 Family 도메인을 추가했습니다.
* 가족 목록 조회 및 단일 조회를 위한 `/api/families` GET API를 구현했습니다.
* 공통 시간 필드를 처리하기 위한 `BaseTimeEntity`와 연동하여 자동으로 created_at / updated_at 이 기록되도록 구성했습니다.

---

## 🔧 Changes

### 1. Family 도메인 추가

* `com.kidk.api.domain.family.Family`

  * ERD 기반으로 `families` 테이블 매핑
  * 주요 컬럼:

    * `familyName`
    * `createdAt`, `updatedAt` (BaseTimeEntity 상속)
  * 단순 구조로 Phase1에서 필요한 **조회 전용 형태**

### 2. Family Repository / Service / Controller 구현

* `FamilyRepository`

  * `JpaRepository<Family, Long>` 상속
  * 전체 조회 및 단건 조회 기능 사용

* `FamilyService`

  * `findAll()` : 전체 가족 목록 조회
  * `findById(Long id)` : PK 기반 단일 조회

* `FamilyController`

  * `@RestController`, `@RequestMapping("/api/families")`
  * `GET /api/families` : 전체 목록 조회
  * `GET /api/families/{familyId}` : 단일 조회

### 3. BaseTimeEntity 적용

* Family 엔티티가 공통으로 생성/수정 시간을 자동 관리하도록
  `BaseTimeEntity` 상속 구조 적용

---

## 🧪 How to Test

1. MySQL에 테스트 데이터 추가

   ```sql
   INSERT INTO families (family_name, created_at, updated_at)
   VALUES ('테스트 패밀리', NOW(), NOW());
   ```

2. 애플리케이션 실행 후 다음 API 호출:

   * `GET http://localhost:8080/api/families`
     → family 리스트(JSON 배열)

   * `GET http://localhost:8080/api/families/1`
     → id=1 패밀리 상세 정보

3. Hibernate SQL 로그에서 SELECT 쿼리 정상 수행되는지 확인

---

## 📌 Notes / Next Steps

* 현재는 엔티티를 그대로 반환하고 있음 → 이후 DTO 레이어 추가 예정
* 이후 family_members 도메인과 연결하여
  `/api/families/{familyId}/members` 구성 예정
* 가족 초대 / 승인 로직은 Phase2에서 구현

